### PR TITLE
Use Integer/MAX_VALUE as timeout

### DIFF
--- a/src/lambda/api.clj
+++ b/src/lambda/api.clj
@@ -38,6 +38,7 @@
           :url url
           :headers headers
           :method method
+          :timeout Integer/MAX_VALUE
           :body (when data
                   (json/generate-string data))}
 


### PR DESCRIPTION
Hi!

I had to add that line to the code so it didn't crash on Lambdas of 60+ seconds. It crashes [here](https://github.com/igrishaev/lambda/blob/de43134/src/lambda/main.clj#L17-L17)